### PR TITLE
Fix bug when default encoding is not UTF8

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -80,7 +80,7 @@ for entry in entries:
 
 out += "\n</smses>"
 
-with open(sms_filename, 'w') as fp:
+with open(sms_filename, 'w', encoding="utf-8") as fp:
     fp.write(out)
 
 cursor = connection.cursor()
@@ -114,7 +114,7 @@ for entry in entries:
     )
 out += "\n</calls>"
 
-with open(calls_filename, 'w') as fp:
+with open(calls_filename, 'w', encoding="utf-8") as fp:
     fp.write(out)
 
 print("Done")


### PR DESCRIPTION
On Windows, you can get a UnicodeEncodeError because default encoding is 1251. Changed to explicitly use UTF8 when writing to files.